### PR TITLE
Utilize more AndroidX Core compatibility implementations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -193,10 +193,8 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.5.0")
     implementation("androidx.fragment:fragment-ktx:1.5.0")
 
-    implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.0")
-    implementation("androidx.lifecycle:lifecycle-common-java8:2.5.0")
     implementation("androidx.lifecycle:lifecycle-process:2.5.0")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.5.0")
 

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/HasApkData.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/HasApkData.kt
@@ -4,6 +4,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PermissionInfo
 import android.os.Build
+import androidx.core.content.pm.PackageInfoCompat
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.common.hasApiLevel
 import eu.darken.myperm.permissions.core.Permission
@@ -20,9 +21,8 @@ interface HasApkData : Pkg {
     val versionName: String?
         get() = packageInfo.versionName
 
-    @Suppress("DEPRECATION")
     val versionCode: Long
-        get() = if (hasApiLevel(28)) packageInfo.longVersionCode else packageInfo.versionCode.toLong()
+        get() = PackageInfoCompat.getLongVersionCode(packageInfo)
 
     val sharedUserId: String?
         get() = packageInfo.sharedUserId

--- a/app/src/main/java/eu/darken/myperm/common/ContextExtensions.kt
+++ b/app/src/main/java/eu/darken/myperm/common/ContextExtensions.kt
@@ -1,8 +1,6 @@
 package eu.darken.myperm.common
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Intent
 import android.content.res.TypedArray
 import android.util.TypedValue
 import androidx.annotation.AttrRes
@@ -34,11 +32,6 @@ fun Context.getCompatColor(@ColorRes attrId: Int): Int {
 
 @ColorInt
 fun Fragment.getCompatColor(@ColorRes attrId: Int): Int = requireContext().getCompatColor(attrId)
-
-@SuppressLint("NewApi")
-fun Context.startServiceCompat(intent: Intent) {
-    if (hasApiLevel(26)) startForegroundService(intent) else startService(intent)
-}
 
 fun Context.dpToPx(dp: Float): Int {
     return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics).toInt()

--- a/app/src/main/java/eu/darken/myperm/common/dagger/AndroidModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/dagger/AndroidModule.kt
@@ -1,9 +1,9 @@
 package eu.darken.myperm.common.dagger
 
 import android.app.Application
-import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.core.app.NotificationManagerCompat
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,6 +25,6 @@ class AndroidModule {
 
     @Provides
     @Singleton
-    fun notificationManager(context: Context): NotificationManager =
-        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    fun notificationManager(context: Context): NotificationManagerCompat =
+        NotificationManagerCompat.from(context)
 }

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -3,6 +3,7 @@ package eu.darken.myperm.common.debug.recording.core
 import android.content.Context
 import android.content.Intent
 import android.os.Environment
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.myperm.common.BuildConfigWrap
 import eu.darken.myperm.common.coroutine.AppScope
@@ -12,7 +13,6 @@ import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.debug.recording.ui.RecorderActivity
 import eu.darken.myperm.common.flow.DynamicStateFlow
-import eu.darken.myperm.common.startServiceCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.plus
@@ -53,7 +53,7 @@ class RecorderModule @Inject constructor(
                         newRecorder.start(createRecordingFilePath())
                         triggerFile.createNewFile()
 
-                        context.startServiceCompat(Intent(context, RecorderService::class.java))
+                        ContextCompat.startForegroundService(context, Intent(context, RecorderService::class.java))
 
                         copy(
                             recorder = newRecorder

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderService.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderService.kt
@@ -1,11 +1,12 @@
 package eu.darken.myperm.common.debug.recording.core
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
 import android.os.IBinder
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.myperm.R
 import eu.darken.myperm.common.BuildConfigWrap
@@ -29,7 +30,7 @@ class RecorderService : Service2() {
     private lateinit var builder: NotificationCompat.Builder
 
     @Inject lateinit var recorderModule: RecorderModule
-    @Inject lateinit var notificationManager: NotificationManager
+    @Inject lateinit var notificationManager: NotificationManagerCompat
     @Inject lateinit var dispatcherProvider: DispatcherProvider
     private val recorderScope by lazy {
         CoroutineScope(SupervisorJob() + dispatcherProvider.IO)
@@ -39,11 +40,10 @@ class RecorderService : Service2() {
 
     override fun onCreate() {
         super.onCreate()
-        NotificationChannel(
-            NOTIF_CHANID_DEBUG,
-            getString(R.string.debug_notification_channel_label),
-            NotificationManager.IMPORTANCE_MAX
-        ).run { notificationManager.createNotificationChannel(this) }
+        NotificationChannelCompat.Builder(NOTIF_CHANID_DEBUG, NotificationManagerCompat.IMPORTANCE_MAX)
+            .setName(getString(R.string.debug_notification_channel_label))
+            .build()
+            .run { notificationManager.createNotificationChannel(this) }
 
         val openIntent = Intent(this, MainActivity::class.java)
         val openPi = PendingIntent.getActivity(
@@ -79,7 +79,7 @@ class RecorderService : Service2() {
                     builder.setContentText("Recording debug log: ${it.currentLogPath?.path}")
                     notificationManager.notify(NOTIFICATION_ID, builder.build())
                 } else {
-                    stopForeground(true)
+                    ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
                     stopSelf()
                 }
             }


### PR DESCRIPTION
### 1st commit

- Remove unused/unneeded lifecycle dependencies

### 2nd commit

- Utilize PackageInfoCompat.getLongVersionCode ([source](https://androidx.tech/artifacts/core/core/1.8.0-source/androidx/core/content/pm/PackageInfoCompat.java.html#:~:text=public%20static%20long-,getLongVersionCode,-(%40NonNull%20PackageInfo)))
- Utilize ContextCompat.startForegroundService ([source](https://androidx.tech/artifacts/core/core/1.8.0-source/androidx/core/content/ContextCompat.java.html#:~:text=public%20static%20void-,startForegroundService,-(%40NonNull%20Context)))
- Utilize ServiceCompat.stopForeground ([source](https://androidx.tech/artifacts/core/core/1.8.0-source/androidx/core/app/ServiceCompat.java.html#:~:text=public%20static%20void-,stopForeground,-(%40NonNull%20Service)))
- Utilize NotificationManagerCompat.from ([source](https://androidx.tech/artifacts/core/core/1.8.0-source/androidx/core/app/NotificationManagerCompat.java.html#:~:text=NotificationManagerCompat%20from))
- Utilize NotificationChannelCompat things ([source](https://androidx.tech/artifacts/core/core/1.8.0-source/androidx/core/app/NotificationChannelCompat.java.html#:~:text=public%20static%20class-,Builder,-%7B%0A%20%20%20%20%20%20%20%20private%20final))
