### PR TITLE
Add `android.permission.FOREGROUND_SERVICE` to known permissions.

### DIFF
--- a/app/src/main/java/eu/darken/myperm/permissions/core/known/AKnownPermissions.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/known/AKnownPermissions.kt
@@ -112,6 +112,10 @@ sealed class AKnownPermissions constructor(override val id: Permission.Id) : Per
         override val iconRes: Int = R.drawable.ic_query_all_packages_24
     }
 
+    object FOREGROUND_SERVICE : AKnownPermissions("android.permission.FOREGROUND_SERVICE") {
+        override val iconRes: Int = R.drawable.ic_foreground_service_24
+    }
+
     companion object {
         val values: List<AKnownPermissions> by lazy {
             AKnownPermissions::class.nestedClasses

--- a/app/src/main/res/drawable/ic_foreground_service_24.xml
+++ b/app/src/main/res/drawable/ic_foreground_service_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.5 8C21.43 8 23 6.43 23 4.5C23 2.57 21.43 1 19.5 1C17.57 1 16 2.57 16 4.5C16 6.43 17.57 8 19.5 8M19.5 10C20 10 20.5 9.93 21 9.79V16C21 18.76 18.76 21 16 21H8C5.24 21 3 18.76 3 16V8C3 5.24 5.24 3 8 3H14.21C14.07 3.5 14 4 14 4.5C14 7.54 16.46 10 19.5 10Z" />
+</vector>


### PR DESCRIPTION
I looked at the list of permissions and noticed `FOREGROUND_SERVICE` didn't have a permission, just a short+long description.

Icon is from `materialdesignicons.com`

```xml
<vector xmlns:android="http://schemas.android.com/apk/res/android"
    android:height="24dp"
    android:width="24dp"
    android:viewportWidth="24"
    android:viewportHeight="24">
    <path android:fillColor="#000" android:pathData="M19.5 8C21.43 8 23 6.43 23 4.5C23 2.57 21.43 1 19.5 1C17.57 1 16 2.57 16 4.5C16 6.43 17.57 8 19.5 8M19.5 10C20 10 20.5 9.93 21 9.79V16C21 18.76 18.76 21 16 21H8C5.24 21 3 18.76 3 16V8C3 5.24 5.24 3 8 3H14.21C14.07 3.5 14 4 14 4.5C14 7.54 16.46 10 19.5 10Z" />
</vector>
```

`android:fillColor` has been replaced with `android:fillColor="@android:color/white"`
and I've added `android:tint="?attr/colorControlNormal"` to `vector`.