### PR TITLE
Funnel ipc buffer data access

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/PackageManagerExtensions.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/PackageManagerExtensions.kt
@@ -48,7 +48,7 @@ fun PackageManager.getPermissionInfo2(
     null
 }
 
-val PackageManager.GET_UNINSTALLED_PACKAGES_COMPAT
+val GET_UNINSTALLED_PACKAGES_COMPAT: Int
     get() = when {
         hasApiLevel(Build.VERSION_CODES.N) -> PackageManager.MATCH_UNINSTALLED_PACKAGES
         else -> PackageManager.GET_UNINSTALLED_PACKAGES

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/PrimaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/PrimaryProfilePkg.kt
@@ -13,6 +13,7 @@ import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.*
 import eu.darken.myperm.apps.core.getIcon2
 import eu.darken.myperm.apps.core.getLabel2
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.permissions.core.Permission
 import eu.darken.myperm.permissions.core.known.APerm
@@ -81,20 +82,20 @@ class PrimaryProfilePkg(
     override fun toString(): String = "PrimaryProfilePkg(packageName=$packageName, userHandle=$userHandle)"
 }
 
-private fun PackageInfo.toNormalPkg(context: Context): PrimaryProfilePkg = PrimaryProfilePkg(
+private suspend fun PackageInfo.toNormalPkg(ipcFunnel: IPCFunnel): PrimaryProfilePkg = PrimaryProfilePkg(
     packageInfo = this,
-    installerInfo = getInstallerInfo(context.packageManager),
-    extraPermissions = determineSpecialPermissions(context),
-    batteryOptimization = determineBatteryOptimization(context),
-    accessibilityServices = determineAccessibilityServices(context),
+    installerInfo = getInstallerInfo(ipcFunnel),
+    extraPermissions = determineSpecialPermissions(ipcFunnel),
+    batteryOptimization = determineBatteryOptimization(ipcFunnel),
+    accessibilityServices = determineAccessibilityServices(ipcFunnel),
 )
 
-suspend fun getNormalPkgs(context: Context): Collection<BasePkg> {
+suspend fun getNormalPkgs(ipcFunnel: IPCFunnel): Collection<BasePkg> {
     log(AppRepo.TAG) { "getNormalPkgs()" }
 
     return coroutineScope {
-        context.packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
-            .map { async { it.toNormalPkg(context) } }
+        ipcFunnel.packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
+            .map { async { it.toNormalPkg(ipcFunnel) } }
             .awaitAll()
     }
 }

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
@@ -1,16 +1,18 @@
 package eu.darken.myperm.apps.core.container
 
 import android.content.Context
-import android.content.pm.*
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
 import android.graphics.drawable.Drawable
 import android.os.Process
 import android.os.UserHandle
-import android.os.UserManager
-import androidx.core.content.ContextCompat
 import eu.darken.myperm.apps.core.AppRepo
 import eu.darken.myperm.apps.core.GET_UNINSTALLED_PACKAGES_COMPAT
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.*
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.common.debug.logging.Logging.Priority.*
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.permissions.core.Permission
@@ -72,21 +74,18 @@ class SecondaryProfilePkg(
     override fun toString(): String = "SecondaryProfilePkg(packageName=$packageName, userHandle=$userHandle)"
 }
 
-suspend fun getSecondaryProfilePkgs(context: Context): Collection<BasePkg> = coroutineScope {
-    val packageManager = context.packageManager
-    val launcherApps = ContextCompat.getSystemService(context, LauncherApps::class.java)!!
-    val userManager = ContextCompat.getSystemService(context, UserManager::class.java)!!
+suspend fun getSecondaryProfilePkgs(ipcFunnel: IPCFunnel): Collection<BasePkg> = coroutineScope {
 
-    val profiles = userManager.userProfiles
+    val profiles = ipcFunnel.userManager.userProfiles()
 
     if (profiles.size < 2) return@coroutineScope emptySet()
 
     log(AppRepo.TAG, INFO) { "Found multiple user profiles: $profiles" }
     val extraProfiles = profiles - Process.myUserHandle()
 
-    fun determineForHandle(userHandle: UserHandle): Collection<BasePkg> {
+    suspend fun determineForHandle(userHandle: UserHandle): Collection<BasePkg> {
         val launcherInfos = try {
-            launcherApps.getActivityList(null, userHandle)
+            ipcFunnel.launcherApps.getActivityList(null, userHandle)
         } catch (e: SecurityException) {
             log(AppRepo.TAG, ERROR) { "Failed to retrieve activity list for $userHandle" }
             emptyList()
@@ -95,15 +94,15 @@ suspend fun getSecondaryProfilePkgs(context: Context): Collection<BasePkg> = cor
         return launcherInfos.mapNotNull { lai ->
             val appInfo = lai.applicationInfo
 
-            var pkgInfo = packageManager.getPackageArchiveInfo(
+            var pkgInfo = ipcFunnel.packageManager.getPackageArchiveInfo(
                 appInfo.packageName,
-                packageManager.GET_UNINSTALLED_PACKAGES_COMPAT
+                GET_UNINSTALLED_PACKAGES_COMPAT
             )
 
             if (pkgInfo == null) {
                 log(AppRepo.TAG, VERBOSE) { "Failed to get info from packagemanager for $appInfo" }
                 pkgInfo =
-                    packageManager.getPackageArchiveInfo(appInfo.sourceDir, PackageManager.GET_PERMISSIONS)
+                    ipcFunnel.packageManager.getPackageArchiveInfo(appInfo.sourceDir, PackageManager.GET_PERMISSIONS)
             }
 
             if (pkgInfo == null) {
@@ -113,10 +112,10 @@ suspend fun getSecondaryProfilePkgs(context: Context): Collection<BasePkg> = cor
 
             SecondaryProfilePkg(
                 packageInfo = pkgInfo,
-                installerInfo = pkgInfo.getInstallerInfo(packageManager),
+                installerInfo = pkgInfo.getInstallerInfo(ipcFunnel),
                 launcherAppInfo = appInfo,
                 userHandle = userHandle,
-                extraPermissions = pkgInfo.determineSpecialPermissions(context),
+                extraPermissions = pkgInfo.determineSpecialPermissions(ipcFunnel),
             ).also { log(AppRepo.TAG) { "PKG[profile=${userHandle}}: $it" } }
         }
     }

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/AccessibilityService.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/AccessibilityService.kt
@@ -1,10 +1,9 @@
 package eu.darken.myperm.apps.core.features
 
 import android.accessibilityservice.AccessibilityServiceInfo
-import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import android.view.accessibility.AccessibilityManager
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.permissions.core.known.APerm
 
 data class AccessibilityService(
@@ -12,14 +11,13 @@ data class AccessibilityService(
     val label: String,
 )
 
-fun PackageInfo.determineAccessibilityServices(context: Context): List<AccessibilityService> {
-    val pm = context.packageManager
-    val acsMan = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
-    val pkgInfo = pm.getPackageInfo(packageName, PackageManager.GET_SERVICES)
+suspend fun PackageInfo.determineAccessibilityServices(ipcFunnel: IPCFunnel): List<AccessibilityService> {
+    val pkgInfo = ipcFunnel.packageManager.getPackageInfo(packageName, PackageManager.GET_SERVICES)
 
-    val enabledAcs = acsMan.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+    val enabledAcs =
+        ipcFunnel.accessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
 
-    return pkgInfo.services
+    return pkgInfo?.services
         ?.filter { it.permission == APerm.BIND_ACCESSIBILITY_SERVICE.id.value }
         ?.map {
             AccessibilityService(

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/BatteryOptimization.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/BatteryOptimization.kt
@@ -1,8 +1,7 @@
 package eu.darken.myperm.apps.core.features
 
-import android.content.Context
 import android.content.pm.PackageInfo
-import android.os.PowerManager
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.common.hasApiLevel
 import eu.darken.myperm.permissions.core.known.APerm
 
@@ -13,15 +12,14 @@ enum class BatteryOptimization {
     UNKNOWN,
 }
 
-fun PackageInfo.determineBatteryOptimization(context: Context): BatteryOptimization {
+suspend fun PackageInfo.determineBatteryOptimization(ipcFunnel: IPCFunnel): BatteryOptimization {
     if (!hasApiLevel(23)) return BatteryOptimization.IGNORED
     if (requestedPermissions == null) return BatteryOptimization.MANAGED_BY_SYSTEM
     if (requestedPermissions.none { it == APerm.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS.id.value }) {
         return BatteryOptimization.MANAGED_BY_SYSTEM
     }
 
-    val pwrm = context.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
-    return if (pwrm.isIgnoringBatteryOptimizations(packageName)) {
+    return if (ipcFunnel.powerManager.isIgnoringBatteryOptimizations(packageName)) {
         BatteryOptimization.IGNORED
     } else {
         BatteryOptimization.OPTIMIZED

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
@@ -1,16 +1,15 @@
 package eu.darken.myperm.apps.core.features
 
-import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.permissions.core.known.AExtraPerm
 
-fun PackageInfo.determineSpecialPermissions(context: Context): Collection<UsesPermission> {
-    val pm = context.packageManager
+suspend fun PackageInfo.determineSpecialPermissions(ipcFunnel: IPCFunnel): Collection<UsesPermission> {
     val permissions = mutableSetOf<UsesPermission>()
 
     val withActivities = try {
-        pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES)
+        ipcFunnel.packageManager.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES)
     } catch (e: PackageManager.NameNotFoundException) {
         null
     }

--- a/app/src/main/java/eu/darken/myperm/common/IPCFunnel.kt
+++ b/app/src/main/java/eu/darken/myperm/common/IPCFunnel.kt
@@ -1,0 +1,124 @@
+package eu.darken.myperm.common
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.content.pm.LauncherActivityInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PermissionGroupInfo
+import android.content.pm.PermissionInfo
+import android.os.UserHandle
+import android.os.UserManager
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.myperm.apps.core.getPackageInfo2
+import eu.darken.myperm.apps.core.getPermissionInfo2
+import eu.darken.myperm.apps.core.tryCreateUserHandle
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.permissions.core.Permission
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IPCFunnel @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    private val execLock = Semaphore(
+        when {
+            hasApiLevel(31) -> 4
+            hasApiLevel(29) -> 3
+            hasApiLevel(26) -> 2
+            else -> 1
+        }.also { log { "IPCFunnel init with parallelization set to $it" } }
+    )
+
+    suspend fun <R> execute(block: suspend IPCFunnel.() -> R): R = execLock.withPermit { block(this) }
+
+    val packageManager by lazy { PackageManager2(this) }
+
+    class PackageManager2(private val ipcFunnel: IPCFunnel) {
+        private val service = ipcFunnel.context.packageManager
+        suspend fun getPackageInfo(packageName: String, flags: Int) = ipcFunnel.execute {
+            service.getPackageInfo2(packageName, flags)
+        }
+
+        suspend fun getInstalledPackages(flags: Int): List<PackageInfo> = ipcFunnel.execute {
+            service.getInstalledPackages(flags)
+        }
+
+        suspend fun getInstallSourceInfo(packageName: String) = ipcFunnel.execute {
+            service.getInstallSourceInfo(packageName)
+        }
+
+        suspend fun getPackageArchiveInfo(path: String, flags: Int) = ipcFunnel.execute {
+            service.getPackageArchiveInfo(path, flags)
+        }
+
+        @Suppress("DEPRECATION")
+        suspend fun getInstallerPackageName(packageName: String) = ipcFunnel.execute {
+            service.getInstallerPackageName(packageName)
+        }
+
+        suspend fun getAllPermissionGroups(flags: Int): List<PermissionGroupInfo> = ipcFunnel.execute {
+            service.getAllPermissionGroups(flags)
+        }
+
+        suspend fun queryPermissionsByGroup(packageName: String?, flags: Int): List<PermissionInfo> =
+            ipcFunnel.execute {
+                service.queryPermissionsByGroup(packageName, flags)
+            }
+
+        suspend fun getPermissionInfo2(permissionId: Permission.Id, flags: Int) = ipcFunnel.execute {
+            service.getPermissionInfo2(permissionId, flags)
+        }
+    }
+
+
+    val powerManager by lazy { PowerManager2(this) }
+
+    class PowerManager2(private val ipcFunnel: IPCFunnel) {
+        private val service = ipcFunnel.context.getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
+
+        suspend fun isIgnoringBatteryOptimizations(packageName: String) = ipcFunnel.execute {
+            service.isIgnoringBatteryOptimizations(packageName)
+        }
+    }
+
+    val accessibilityManager by lazy { AccessibilityManager2(this) }
+
+    class AccessibilityManager2(private val ipcFunnel: IPCFunnel) {
+        private val service =
+            ipcFunnel.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as android.view.accessibility.AccessibilityManager
+
+        suspend fun getEnabledAccessibilityServiceList(flags: Int): List<AccessibilityServiceInfo> =
+            service.getEnabledAccessibilityServiceList(flags)
+    }
+
+    val launcherApps by lazy { LauncherApps2(this) }
+
+    class LauncherApps2(private val ipcFunnel: IPCFunnel) {
+        private val service =
+            ContextCompat.getSystemService(ipcFunnel.context, android.content.pm.LauncherApps::class.java)!!
+
+        suspend fun getActivityList(packageName: String?, userHandle: UserHandle): List<LauncherActivityInfo> =
+            ipcFunnel.execute {
+                service.getActivityList(packageName, userHandle)
+            }
+    }
+
+    val userManager by lazy { UserManager2(this) }
+
+    class UserManager2(private val ipcFunnel: IPCFunnel) {
+        private val service = ContextCompat.getSystemService(ipcFunnel.context, UserManager::class.java)!!
+
+        suspend fun userProfiles(): List<UserHandle> = ipcFunnel.execute {
+            service.userProfiles
+        }
+
+        suspend fun tryCreateUserHandle(handle: Int) = ipcFunnel.execute {
+            service.tryCreateUserHandle(handle)
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/common/coil/AppIconFetcher.kt
+++ b/app/src/main/java/eu/darken/myperm/common/coil/AppIconFetcher.kt
@@ -1,6 +1,5 @@
 package eu.darken.myperm.common.coil
 
-import android.content.pm.PackageManager
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.LayerDrawable
@@ -17,18 +16,19 @@ import coil.size.pxOrElse
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.Installed
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.common.dpToPx
 import eu.darken.myperm.common.getColorForAttr
 import javax.inject.Inject
 
 class AppIconFetcher @Inject constructor(
-    private val packageManager: PackageManager,
+    private val ipcFunnel: IPCFunnel,
     private val data: Pkg,
     private val options: Options,
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult {
-        val baseIcon = data.getIcon(options.context) ?: ColorDrawable(Color.TRANSPARENT)
+        val baseIcon = ipcFunnel.execute { data.getIcon(options.context) } ?: ColorDrawable(Color.TRANSPARENT)
 
         var isSampled = false
 
@@ -67,14 +67,14 @@ class AppIconFetcher @Inject constructor(
     }
 
     class Factory @Inject constructor(
-        private val packageManager: PackageManager,
+        private val ipcFunnel: IPCFunnel,
     ) : Fetcher.Factory<Pkg> {
 
         override fun create(
             data: Pkg,
             options: Options,
             imageLoader: ImageLoader
-        ): Fetcher = AppIconFetcher(packageManager, data, options)
+        ): Fetcher = AppIconFetcher(ipcFunnel, data, options)
     }
 }
 

--- a/app/src/main/java/eu/darken/myperm/common/coil/PermissionIconFetcher.kt
+++ b/app/src/main/java/eu/darken/myperm/common/coil/PermissionIconFetcher.kt
@@ -1,6 +1,5 @@
 package eu.darken.myperm.common.coil
 
-import android.content.pm.PackageManager
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import coil.ImageLoader
@@ -9,30 +8,31 @@ import coil.fetch.DrawableResult
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.Options
+import eu.darken.myperm.common.IPCFunnel
 import eu.darken.myperm.permissions.core.Permission
 import javax.inject.Inject
 
 
 class PermissionIconFetcher @Inject constructor(
-    private val packageManager: PackageManager,
+    private val ipcFunnel: IPCFunnel,
     private val data: Permission,
     private val options: Options,
 ) : Fetcher {
     override suspend fun fetch(): FetchResult = DrawableResult(
-        drawable = data.getIcon(options.context) ?: ColorDrawable(Color.TRANSPARENT),
+        drawable = ipcFunnel.execute { data.getIcon(options.context) } ?: ColorDrawable(Color.TRANSPARENT),
         isSampled = false,
         dataSource = DataSource.MEMORY
     )
 
     class Factory @Inject constructor(
-        private val packageManager: PackageManager,
+        private val ipcFunnel: IPCFunnel,
     ) : Fetcher.Factory<Permission> {
 
         override fun create(
             data: Permission,
             options: Options,
             imageLoader: ImageLoader
-        ): Fetcher = PermissionIconFetcher(packageManager, data, options)
+        ): Fetcher = PermissionIconFetcher(ipcFunnel, data, options)
     }
 }
 

--- a/app/src/main/java/eu/darken/myperm/common/dagger/AndroidModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/dagger/AndroidModule.kt
@@ -2,12 +2,10 @@ package eu.darken.myperm.common.dagger
 
 import android.app.Application
 import android.content.Context
-import android.content.pm.PackageManager
 import androidx.core.app.NotificationManagerCompat
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -18,10 +16,6 @@ class AndroidModule {
     @Provides
     @Singleton
     fun context(app: Application): Context = app.applicationContext
-
-    @Provides
-    @Singleton
-    fun packagemanager(@ApplicationContext context: Context): PackageManager = context.packageManager
 
     @Provides
     @Singleton


### PR DESCRIPTION
Funnel data access that traverses the IPC buffer to prevent overflows and `android.os.DeadObjectException` on older Android versions with smaller buffer sizes.
Fixes crash on ~ Android 6 when loading a lot of app data simultaneously.